### PR TITLE
예약 가능한 좌석 및 날짜 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/concertticketing/api/concert/ConcertController.java
+++ b/src/main/java/com/example/concertticketing/api/concert/ConcertController.java
@@ -1,0 +1,37 @@
+package com.example.concertticketing.api.concert;
+
+import com.example.concertticketing.domain.concert.model.ConcertDate;
+import com.example.concertticketing.domain.concert.model.ConcertSeat;
+import com.example.concertticketing.domain.concert.service.ConcertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/concert")
+public class ConcertController {
+
+    private final ConcertService concertService;
+
+    /**
+     * 예약 가능한 날짜 목록 조회
+     * */
+    @GetMapping("/date/{concertId}")
+    public ResponseEntity<ConcertDate> getAvailableDates(@PathVariable("concertId") Long concertId) {
+        return ResponseEntity.ok(concertService.selectAvailableDates(concertId));
+    }
+
+    /**
+     * 예약 가능 좌석 조회
+     * */
+    @GetMapping("/seat/{concertDetailId}")
+    public ResponseEntity<ConcertSeat> getAvailableSeats(
+              @PathVariable("concertDetailId") Long concertDetailId) {
+        return ResponseEntity.ok(concertService.selectAvailableSeats(concertDetailId));
+    }
+}
+

--- a/src/main/java/com/example/concertticketing/api/concert/dto/ConcertDateResponse.java
+++ b/src/main/java/com/example/concertticketing/api/concert/dto/ConcertDateResponse.java
@@ -1,0 +1,18 @@
+package com.example.concertticketing.api.concert.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ConcertDateResponse {
+    List<String> dates;
+
+    @Builder
+    public ConcertDateResponse(List<String> dates) {
+        this.dates = dates;
+    }
+}

--- a/src/main/java/com/example/concertticketing/api/concert/dto/ConcertSeatResponse.java
+++ b/src/main/java/com/example/concertticketing/api/concert/dto/ConcertSeatResponse.java
@@ -1,0 +1,18 @@
+package com.example.concertticketing.api.concert.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ConcertSeatResponse {
+    List<Integer> seats;
+
+    @Builder
+    public ConcertSeatResponse(List<Integer> seats) {
+        this.seats = seats;
+    }
+}

--- a/src/main/java/com/example/concertticketing/api/pay/PayController.java
+++ b/src/main/java/com/example/concertticketing/api/pay/PayController.java
@@ -1,0 +1,26 @@
+package com.example.concertticketing.api.pay;
+
+import com.example.concertticketing.api.pay.dto.PayRequest;
+import com.example.concertticketing.api.pay.dto.PayResponse;
+import com.example.concertticketing.domain.pay.service.PayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/pay")
+public class PayController {
+    private final PayService payService;
+
+    /**
+     * 결제 요청
+     * */
+    @PostMapping("")
+    public ResponseEntity<PayResponse> pay(@RequestBody PayRequest request) {
+        return ResponseEntity.ok(PayResponse.of(payService.pay(request)));
+    }
+}

--- a/src/main/java/com/example/concertticketing/api/pay/dto/PayRequest.java
+++ b/src/main/java/com/example/concertticketing/api/pay/dto/PayRequest.java
@@ -1,0 +1,9 @@
+package com.example.concertticketing.api.pay.dto;
+
+public record PayRequest(
+        Long reservationId,
+        Long seatId,
+        Long memberId
+) {
+
+}

--- a/src/main/java/com/example/concertticketing/api/pay/dto/PayResponse.java
+++ b/src/main/java/com/example/concertticketing/api/pay/dto/PayResponse.java
@@ -1,0 +1,26 @@
+package com.example.concertticketing.api.pay.dto;
+
+import com.example.concertticketing.domain.pay.model.Pay;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PayResponse {
+    Long amount;
+    int seat;
+
+    @Builder
+    public PayResponse(Long amount, int seat) {
+        this.amount = amount;
+        this.seat = seat;
+    }
+
+    public static PayResponse of(Pay pay) {
+        return PayResponse.builder()
+                .seat(pay.getReservation().getSeatNo())
+                .amount(pay.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/example/concertticketing/api/reservation/ReservationController.java
+++ b/src/main/java/com/example/concertticketing/api/reservation/ReservationController.java
@@ -1,0 +1,27 @@
+package com.example.concertticketing.api.reservation;
+
+import com.example.concertticketing.api.reservation.dto.ReserveSeatRequest;
+import com.example.concertticketing.api.reservation.dto.ReserveSeatResponse;
+import com.example.concertticketing.domain.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reserve")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    /**
+     * 좌석 예약
+     * */
+    @PostMapping("")
+    public ResponseEntity<ReserveSeatResponse> reserveSeat(@RequestBody ReserveSeatRequest request) {
+        return ResponseEntity.ok(ReserveSeatResponse.of(reservationService.reserveSeat(request.seatId())));
+    }
+}

--- a/src/main/java/com/example/concertticketing/api/reservation/dto/ReserveSeatRequest.java
+++ b/src/main/java/com/example/concertticketing/api/reservation/dto/ReserveSeatRequest.java
@@ -1,0 +1,7 @@
+package com.example.concertticketing.api.reservation.dto;
+
+public record ReserveSeatRequest(
+        Long seatId
+) {
+
+}

--- a/src/main/java/com/example/concertticketing/api/reservation/dto/ReserveSeatResponse.java
+++ b/src/main/java/com/example/concertticketing/api/reservation/dto/ReserveSeatResponse.java
@@ -1,0 +1,27 @@
+package com.example.concertticketing.api.reservation.dto;
+
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.model.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReserveSeatResponse {
+    int seat;
+    ReservationStatus status;
+
+    @Builder
+    public ReserveSeatResponse(int seat,ReservationStatus status) {
+        this.seat = seat;
+        this.status = status;
+    }
+
+    public static ReserveSeatResponse of(Reservation reservation) {
+        return ReserveSeatResponse.builder()
+                .seat(reservation.getSeatNo())
+                .status(reservation.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/infrastructure/ConcertDetailJpaRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/infrastructure/ConcertDetailJpaRepository.java
@@ -1,0 +1,13 @@
+package com.example.concertticketing.domain.concert.infrastructure;
+
+import com.example.concertticketing.domain.concert.model.ConcertDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ConcertDetailJpaRepository extends JpaRepository<ConcertDetail,Long> {
+    @Query("SELECT c FROM ConcertDetail c WHERE c.concert.id = :concertId")
+    List<ConcertDetail> findByConcertId(@Param("concertId") Long concertId);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/infrastructure/SeatJpaRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/infrastructure/SeatJpaRepository.java
@@ -1,0 +1,14 @@
+package com.example.concertticketing.domain.concert.infrastructure;
+
+import com.example.concertticketing.domain.concert.model.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SeatJpaRepository extends JpaRepository<Seat,Long> {
+    @Query("SELECT s FROM Seat s WHERE s.concert.id = :concertDetailId AND (s.reservedAt IS NULL OR s.reservedAt < :time)")
+    List<Seat> findSeatsByConcertIdAndType(@Param("concertDetailId") Long concertDetailId, @Param("time") LocalDateTime time);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/model/ConcertDate.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/model/ConcertDate.java
@@ -1,9 +1,9 @@
 package com.example.concertticketing.domain.concert.model;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record ConcertDate(
-        Long concertDetailId,
-        LocalDateTime dates
+        Long concertId,
+        List<ConcertDateDetails> concertDates
 ) {
 }

--- a/src/main/java/com/example/concertticketing/domain/concert/model/ConcertDateDetails.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/model/ConcertDateDetails.java
@@ -1,9 +1,9 @@
 package com.example.concertticketing.domain.concert.model;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
-public record ConcertSeat(
+public record ConcertDateDetails(
         Long concertDetailId,
-        List<ConcertSeatDetail> concertSeats
+        LocalDateTime dates
 ) {
 }

--- a/src/main/java/com/example/concertticketing/domain/concert/model/ConcertSeatDetail.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/model/ConcertSeatDetail.java
@@ -1,0 +1,7 @@
+package com.example.concertticketing.domain.concert.model;
+
+public record ConcertSeatDetail(
+        Long seatId,
+        int seatNo
+) {
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/model/Seat.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/model/Seat.java
@@ -37,34 +37,20 @@ public class Seat extends BaseEntity {
     @Column(name = "PRICE")
     private Long price;
 
-    // 5분간 임시 지정을 위함
-    @Column(name = "EXPIRED_AT")
-    private LocalDateTime expiredAt;
-
-    @Enumerated(EnumType.STRING) // DB 저장 시 문자열로 저장
-    @Column(name = "STATUS")
-    private SeatStatus status; // AVAILABLE, TEMPORARY, RESERVED
+    @Column(name = "RESERVED_AT")
+    private LocalDateTime reservedAt;
 
     @Builder
-    public Seat(Long id, Member member, ConcertDetail concert, int seatNo, Long price, LocalDateTime expiredAt, SeatStatus status) {
+    public Seat(Long id, Member member, ConcertDetail concert, int seatNo, Long price, LocalDateTime reservedAt) {
         this.id = id;
         this.member = member;
         this.concert = concert;
         this.seatNo = seatNo;
         this.price = price;
-        this.expiredAt = expiredAt;
-        this.status = status;
+        this.reservedAt = reservedAt;
     }
 
-    public boolean isAvailable() {
-        if (this.status == SeatStatus.AVAILABLE) {
-            return true;
-        }
-
-        return false;
-    }
-
-    public void updateStatus(SeatStatus status) {
-        this.status = status;
+    public void updateReservedAt(LocalDateTime reservedAt) {
+        this.reservedAt = reservedAt;
     }
 }

--- a/src/main/java/com/example/concertticketing/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/repository/ConcertRepository.java
@@ -1,0 +1,15 @@
+package com.example.concertticketing.domain.concert.repository;
+
+
+import com.example.concertticketing.domain.concert.model.ConcertDetail;
+import com.example.concertticketing.domain.concert.model.Seat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ConcertRepository {
+
+    List<ConcertDetail> findDatesByConcertId(Long concertId);
+
+    List<Seat> findAvailableSeatsByConcertId(Long concertDetailId, LocalDateTime time);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/repository/ConcertRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.example.concertticketing.domain.concert.repository;
+
+import com.example.concertticketing.domain.concert.infrastructure.ConcertDetailJpaRepository;
+import com.example.concertticketing.domain.concert.infrastructure.SeatJpaRepository;
+import com.example.concertticketing.domain.concert.model.ConcertDetail;
+import com.example.concertticketing.domain.concert.model.Seat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ConcertRepositoryImpl implements ConcertRepository {
+
+    private final ConcertDetailJpaRepository concertDetailJpaRepository;
+    private final SeatJpaRepository seatJpaRepository;
+
+    @Override
+    public List<ConcertDetail> findDatesByConcertId(Long concertId) {
+        return concertDetailJpaRepository.findByConcertId(concertId);
+    }
+
+    @Override
+    public List<Seat> findAvailableSeatsByConcertId(Long concertDetailId, LocalDateTime time) {
+        return seatJpaRepository.findSeatsByConcertIdAndType(concertDetailId, time);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/repository/SeatRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/repository/SeatRepository.java
@@ -1,0 +1,10 @@
+package com.example.concertticketing.domain.concert.repository;
+
+
+import com.example.concertticketing.domain.concert.model.Seat;
+
+import java.util.Optional;
+
+public interface SeatRepository {
+    Optional<Seat> findById(Long seatId);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/repository/SeatRepositoryImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/repository/SeatRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.example.concertticketing.domain.concert.repository;
+
+import com.example.concertticketing.domain.concert.infrastructure.SeatJpaRepository;
+import com.example.concertticketing.domain.concert.model.Seat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class SeatRepositoryImpl implements SeatRepository {
+
+    private final SeatJpaRepository seatJpaRepository;
+
+    @Override
+    public Optional<Seat> findById(Long seatId) {
+        return seatJpaRepository.findById(seatId);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/service/ConcertService.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/service/ConcertService.java
@@ -1,0 +1,10 @@
+package com.example.concertticketing.domain.concert.service;
+
+import com.example.concertticketing.domain.concert.model.ConcertDate;
+import com.example.concertticketing.domain.concert.model.ConcertSeat;
+
+public interface ConcertService {
+    ConcertDate selectAvailableDates(Long concertId);
+
+    ConcertSeat selectAvailableSeats(Long concertDetailId);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/service/ConcertServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.concertticketing.domain.concert.service;
+
+import com.example.concertticketing.domain.concert.model.ConcertDate;
+import com.example.concertticketing.domain.concert.model.ConcertDateDetails;
+import com.example.concertticketing.domain.concert.model.ConcertSeat;
+import com.example.concertticketing.domain.concert.model.ConcertSeatDetail;
+import com.example.concertticketing.domain.concert.repository.ConcertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ConcertServiceImpl implements ConcertService {
+
+    private final ConcertRepository concertRepository;
+
+
+    @Override
+    public ConcertDate selectAvailableDates(Long concertId) {
+        List<ConcertDateDetails> details = concertRepository.findDatesByConcertId(concertId).stream()
+                .map(entity -> new ConcertDateDetails(entity.getId(), entity.getDate()))
+                .collect(Collectors.toList());
+        return new ConcertDate(concertId, details);
+    }
+
+    @Override
+    public ConcertSeat selectAvailableSeats(Long concertDetailId) {
+        List<ConcertSeatDetail> details = concertRepository.findAvailableSeatsByConcertId(concertDetailId, LocalDateTime.now().minusSeconds(10)).stream()
+                .map(entity -> new ConcertSeatDetail(entity.getId(), entity.getSeatNo()))
+                .collect(Collectors.toList());
+        return new ConcertSeat(concertDetailId, details);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/service/SeatService.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/service/SeatService.java
@@ -1,0 +1,12 @@
+package com.example.concertticketing.domain.concert.service;
+
+
+import com.example.concertticketing.domain.concert.model.Seat;
+
+import java.time.LocalDateTime;
+
+public interface SeatService {
+    Seat selectSeat(Long seatId);
+
+    void updateReservedAt(Long seatId, LocalDateTime now);
+}

--- a/src/main/java/com/example/concertticketing/domain/concert/service/SeatServiceImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/concert/service/SeatServiceImpl.java
@@ -1,0 +1,29 @@
+package com.example.concertticketing.domain.concert.service;
+
+import com.example.concertticketing.domain.concert.model.Seat;
+import com.example.concertticketing.domain.concert.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class SeatServiceImpl implements SeatService {
+    private final SeatRepository seatRepository;
+
+    @Override
+    public Seat selectSeat(Long seatId) {
+        return seatRepository.findById(seatId)
+                .orElseThrow(() -> new NullPointerException("좌석 정보가 존재하지 않습니다"));
+    }
+
+    @Transactional
+    @Override
+    public void updateReservedAt(Long seatId, LocalDateTime now) {
+        Seat seat = selectSeat(seatId);
+        seat.updateReservedAt(now);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/pay/infrastructure/PayJpaRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/pay/infrastructure/PayJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.concertticketing.domain.pay.infrastructure;
+
+import com.example.concertticketing.domain.pay.model.Pay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayJpaRepository extends JpaRepository<Pay,Long> {
+}

--- a/src/main/java/com/example/concertticketing/domain/pay/repository/PayRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/pay/repository/PayRepository.java
@@ -1,0 +1,9 @@
+package com.example.concertticketing.domain.pay.repository;
+
+
+import com.example.concertticketing.domain.pay.model.Pay;
+
+public interface PayRepository {
+
+    Pay pay(Pay pay);
+}

--- a/src/main/java/com/example/concertticketing/domain/pay/repository/PayRepositoryImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/pay/repository/PayRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.example.concertticketing.domain.pay.repository;
+
+import com.example.concertticketing.domain.pay.infrastructure.PayJpaRepository;
+import com.example.concertticketing.domain.pay.model.Pay;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PayRepositoryImpl implements PayRepository {
+
+    private final PayJpaRepository payJpaRepository;
+
+    @Override
+    public Pay pay(Pay pay) {
+        return payJpaRepository.save(pay);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/pay/service/PayService.java
+++ b/src/main/java/com/example/concertticketing/domain/pay/service/PayService.java
@@ -1,0 +1,9 @@
+package com.example.concertticketing.domain.pay.service;
+
+import com.example.concertticketing.api.pay.dto.PayRequest;
+import com.example.concertticketing.domain.pay.model.Pay;
+
+public interface PayService {
+
+    Pay pay(PayRequest request);
+}

--- a/src/main/java/com/example/concertticketing/domain/pay/service/PayServiceImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/pay/service/PayServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.concertticketing.domain.pay.service;
+
+import com.example.concertticketing.api.pay.dto.PayRequest;
+import com.example.concertticketing.domain.concert.service.SeatService;
+import com.example.concertticketing.domain.pay.model.Pay;
+import com.example.concertticketing.domain.pay.model.PayStatus;
+import com.example.concertticketing.domain.pay.repository.PayRepository;
+import com.example.concertticketing.domain.queue.model.QueueStatus;
+import com.example.concertticketing.domain.queue.service.QueueService;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PayServiceImpl implements PayService {
+    private final PayRepository payRepository;
+    private final ReservationService reservationService;
+    private final QueueService queueService;
+    private final SeatService seatService;
+
+    @Transactional
+    @Override
+    public Pay pay(PayRequest request) {
+        Reservation reservation = reservationService.findById(request.reservationId());
+        if (reservation.getMemberId() != request.memberId()) {
+            throw new IllegalStateException("멤버 정보와 예약 정보가 일치하지 않습니다");
+        }
+
+        Pay pay = Pay.builder()
+                .reservation(reservation)
+                .amount(reservation.getPrice())
+                .status(PayStatus.PAYED)
+                .build();
+
+        queueService.expiredToken(request.memberId(), QueueStatus.EXPIRED);
+        seatService.updateReservedAt(request.seatId(), LocalDateTime.of(9999, 12, 31, 23, 59, 59));
+
+        return payRepository.pay(pay);
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/reservation/infrastructure/ReservationJpaRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/reservation/infrastructure/ReservationJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.concertticketing.domain.reservation.infrastructure;
+
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationJpaRepository extends JpaRepository<Reservation,Long> {
+}

--- a/src/main/java/com/example/concertticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/concertticketing/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,10 @@
+package com.example.concertticketing.domain.reservation.repository;
+
+import com.example.concertticketing.domain.reservation.model.Reservation;
+
+public interface ReservationRepository {
+
+    Reservation reserveSeat(Reservation reservation);
+
+    Reservation findById(Long reservationId);
+}

--- a/src/main/java/com/example/concertticketing/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.example.concertticketing.domain.reservation.repository;
+
+import com.example.concertticketing.domain.reservation.infrastructure.ReservationJpaRepository;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ReservationRepositoryImpl implements ReservationRepository {
+
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    @Override
+    public Reservation reserveSeat(Reservation reservation) {
+        return reservationJpaRepository.save(reservation);
+    }
+
+    @Override
+    public Reservation findById(Long reservationId) {
+        return reservationJpaRepository.findById(reservationId)
+                .orElseThrow(() -> new NullPointerException("일치하는 예약번호가 없습니다"));
+    }
+}

--- a/src/main/java/com/example/concertticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/concertticketing/domain/reservation/service/ReservationService.java
@@ -1,0 +1,10 @@
+package com.example.concertticketing.domain.reservation.service;
+
+
+import com.example.concertticketing.domain.reservation.model.Reservation;
+
+public interface ReservationService {
+    Reservation reserveSeat(Long seatId);
+
+    Reservation findById(Long reservationId);
+}

--- a/src/main/java/com/example/concertticketing/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/example/concertticketing/domain/reservation/service/ReservationServiceImpl.java
@@ -1,0 +1,54 @@
+package com.example.concertticketing.domain.reservation.service;
+
+import com.example.concertticketing.domain.concert.model.Seat;
+import com.example.concertticketing.domain.concert.service.SeatService;
+import com.example.concertticketing.domain.exception.CustomException;
+import com.example.concertticketing.domain.exception.ErrorEnum;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.model.ReservationStatus;
+import com.example.concertticketing.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ReservationServiceImpl implements ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final SeatService seatService;
+
+    @Transactional
+    @Override
+    public Reservation reserveSeat(Long seatId) {
+        Seat seat = seatService.selectSeat(seatId);
+        LocalDateTime reservedAt = seat.getReservedAt();
+        LocalDateTime now = LocalDateTime.now();
+
+        if (reservedAt != null && reservedAt.plusSeconds(15).isAfter(now)) {
+            throw new CustomException(ErrorEnum.RESERVED_SEAT);
+        }
+
+        seatService.updateReservedAt(seatId, now);
+
+        Reservation reservation = Reservation.builder()
+                .seat(seat)
+                .concertName(seat.getConcert().getName())
+                .price(seat.getPrice())
+                .seatNo(seat.getSeatNo())
+                .memberId(seat.getMember().getId())
+                .date(seat.getConcert().getDate())
+                .status(ReservationStatus.RESERVED)
+                .build();
+
+        return reservationRepository.reserveSeat(reservation);
+    }
+
+    @Override
+    public Reservation findById(Long reservationId) {
+        return reservationRepository.findById(reservationId);
+    }
+}

--- a/src/test/java/com/example/concertticketing/CommonControllerTest.java
+++ b/src/test/java/com/example/concertticketing/CommonControllerTest.java
@@ -2,10 +2,14 @@ package com.example.concertticketing;
 
 import com.example.concertticketing.api.concert.ConcertController;
 import com.example.concertticketing.api.member.MemberController;
+import com.example.concertticketing.api.pay.PayController;
 import com.example.concertticketing.api.queue.QueueController;
+import com.example.concertticketing.api.reservation.ReservationController;
 import com.example.concertticketing.domain.concert.service.ConcertServiceImpl;
 import com.example.concertticketing.domain.member.service.MemberServiceImpl;
+import com.example.concertticketing.domain.pay.service.PayServiceImpl;
 import com.example.concertticketing.domain.queue.service.QueueServiceImpl;
+import com.example.concertticketing.domain.reservation.service.ReservationServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -13,9 +17,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
+        ConcertController.class,
+        PayController.class,
         MemberController.class,
         QueueController.class,
-        ConcertController.class,
+        ReservationController.class,
 })
 public abstract class CommonControllerTest {
     @Autowired
@@ -33,4 +39,9 @@ public abstract class CommonControllerTest {
     @MockBean
     protected ConcertServiceImpl concertService;
 
+    @MockBean
+    protected ReservationServiceImpl reservationService;
+
+    @MockBean
+    protected PayServiceImpl payService;
 }

--- a/src/test/java/com/example/concertticketing/CommonControllerTest.java
+++ b/src/test/java/com/example/concertticketing/CommonControllerTest.java
@@ -1,7 +1,9 @@
 package com.example.concertticketing;
 
+import com.example.concertticketing.api.concert.ConcertController;
 import com.example.concertticketing.api.member.MemberController;
 import com.example.concertticketing.api.queue.QueueController;
+import com.example.concertticketing.domain.concert.service.ConcertServiceImpl;
 import com.example.concertticketing.domain.member.service.MemberServiceImpl;
 import com.example.concertticketing.domain.queue.service.QueueServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
         MemberController.class,
         QueueController.class,
+        ConcertController.class,
 })
 public abstract class CommonControllerTest {
     @Autowired
@@ -26,5 +29,8 @@ public abstract class CommonControllerTest {
 
     @MockBean
     protected QueueServiceImpl queueService;
+
+    @MockBean
+    protected ConcertServiceImpl concertService;
 
 }

--- a/src/test/java/com/example/concertticketing/api/concert/ConcertControllerTest.java
+++ b/src/test/java/com/example/concertticketing/api/concert/ConcertControllerTest.java
@@ -1,0 +1,94 @@
+package com.example.concertticketing.api.concert;
+
+import com.example.concertticketing.CommonControllerTest;
+import com.example.concertticketing.domain.concert.model.ConcertDate;
+import com.example.concertticketing.domain.concert.model.ConcertDateDetails;
+import com.example.concertticketing.domain.concert.model.ConcertSeat;
+import com.example.concertticketing.domain.concert.model.ConcertSeatDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ConcertControllerTest extends CommonControllerTest {
+
+    @DisplayName("예약 가능한 날짜 목록을 조회한다")
+    @Test
+    void getAvailableDates() throws Exception {
+        // given
+        Long concertId = 1L;
+        Long memberId = 1L;
+        LocalDateTime today = LocalDateTime.now();
+        List<ConcertDateDetails> details = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            details.add(new ConcertDateDetails(concertId + i, today.plusDays(i)));
+        }
+
+        ConcertDate response = new ConcertDate(concertId, details);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+
+        // when
+        when(queueService.verify(memberId)).thenReturn(true);
+        when(concertService.selectAvailableDates(any())).thenReturn(response);
+
+        // then
+        mockMvc.perform(get("/api/concert/date/{concertId}", concertId)
+                        .header("memberId",memberId)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.concertId").value(concertId))
+                .andExpect(jsonPath("$.data.concertDates[0].dates").value(today.plusDays(0).format(formatter)))
+                .andExpect(jsonPath("$.data.concertDates[0].concertDetailId").value(1L))
+                .andExpect(jsonPath("$.data.concertDates[1].dates").value(today.plusDays(1).format(formatter)))
+                .andExpect(jsonPath("$.data.concertDates[1].concertDetailId").value(2L))
+        ;
+    }
+
+    @DisplayName("예약 가능한 좌석 목록을 조회한다")
+    @Test
+    void getAvailableSeats() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long concertDetailId = 1L;
+        Long seatId = 1L;
+        int seatNo = 1;
+        List<ConcertSeatDetail> details = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            details.add(new ConcertSeatDetail(seatId + i, seatNo + i));
+        }
+
+        ConcertSeat response = new ConcertSeat(concertDetailId, details);
+
+        // when
+        when(queueService.verify(memberId)).thenReturn(true);
+        when(concertService.selectAvailableSeats(any())).thenReturn(response);
+
+        // then
+        mockMvc.perform(get("/api/concert/seat/{concertId}", concertDetailId)
+                        .header("memberId",memberId)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.concertDetailId").value(concertDetailId))
+                .andExpect(jsonPath("$.data.concertSeats[0].seatId").value(1L))
+                .andExpect(jsonPath("$.data.concertSeats[0].seatNo").value(1))
+                .andExpect(jsonPath("$.data.concertSeats[1].seatId").value(2L))
+                .andExpect(jsonPath("$.data.concertSeats[1].seatNo").value(2))
+        ;
+    }
+}

--- a/src/test/java/com/example/concertticketing/api/pay/PayControllerTest.java
+++ b/src/test/java/com/example/concertticketing/api/pay/PayControllerTest.java
@@ -1,0 +1,54 @@
+package com.example.concertticketing.api.pay;
+
+import com.example.concertticketing.CommonControllerTest;
+import com.example.concertticketing.api.pay.dto.PayRequest;
+import com.example.concertticketing.domain.pay.model.Pay;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PayControllerTest extends CommonControllerTest {
+
+    @DisplayName("예약 번호를 받아 해당 예약을 결제한다")
+    @Test
+    void pay() throws Exception {
+        // given
+        Long reservationId = 1L;
+        Long memberId = 1L;
+        Long seatId = 1L;
+        int seatNo = 2;
+        Long amount = 5000L;
+
+        PayRequest request = new PayRequest(reservationId,memberId,seatId);
+        Reservation reservation = Reservation.builder()
+                .seatNo(seatNo)
+                .build();
+
+        Pay pay = Pay.builder()
+                .reservation(reservation)
+                .amount(amount)
+                .build();
+
+        // when
+        when(queueService.verify(memberId)).thenReturn(true);
+        when(payService.pay(any())).thenReturn(pay);
+
+        // then
+        mockMvc.perform(post("/api/pay")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("memberId",memberId)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.amount").value(amount))
+                .andExpect(jsonPath("$.data.seat").value(seatNo))
+        ;
+    }
+}

--- a/src/test/java/com/example/concertticketing/api/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/example/concertticketing/api/reservation/ReservationControllerTest.java
@@ -1,0 +1,51 @@
+package com.example.concertticketing.api.reservation;
+
+import com.example.concertticketing.CommonControllerTest;
+import com.example.concertticketing.api.reservation.dto.ReserveSeatRequest;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.model.ReservationStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReservationControllerTest extends CommonControllerTest {
+
+    @DisplayName("좌석을 예약한다")
+    @Test
+    void reserveSeat() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long seatId = 1L;
+        int seatNo = 2;
+        ReservationStatus status = ReservationStatus.RESERVED;
+
+        ReserveSeatRequest request = new ReserveSeatRequest(seatId);
+        Reservation reservation = Reservation.builder()
+                .seatNo(seatNo)
+                .status(status)
+                .build();
+
+        // when
+        when(queueService.verify(memberId)).thenReturn(true);
+        when(reservationService.reserveSeat(any())).thenReturn(reservation);
+
+        // then
+        mockMvc.perform(post("/api/reserve")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("memberId",memberId)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.seat").value(seatNo))
+                .andExpect(jsonPath("$.data.status").value(status.toString()))
+        ;
+    }
+}

--- a/src/test/java/com/example/concertticketing/domain/concert/service/ConcertServiceTest.java
+++ b/src/test/java/com/example/concertticketing/domain/concert/service/ConcertServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.concertticketing.domain.concert.service;
+
+import com.example.concertticketing.domain.concert.model.ConcertDate;
+import com.example.concertticketing.domain.concert.model.ConcertDetail;
+import com.example.concertticketing.domain.concert.model.ConcertSeat;
+import com.example.concertticketing.domain.concert.model.Seat;
+import com.example.concertticketing.domain.concert.repository.ConcertRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertServiceTest {
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @InjectMocks
+    private ConcertServiceImpl concertService;
+
+    @DisplayName("콘서트 별 예약 가능한 날짜를 조회한다")
+    @Test
+    void selectAvailableDates() {
+        // given
+        Long concertId = 1L;
+        Long concertDetailId = 1L;
+        LocalDateTime today = LocalDateTime.now();
+
+        List<ConcertDetail> details = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            ConcertDetail concert = ConcertDetail.builder()
+                    .id(concertDetailId + i)
+                    .date(today.plusDays(i))
+                    .build();
+
+            details.add(concert);
+        }
+
+
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+
+        // when
+        when(concertRepository.findDatesByConcertId(any())).thenReturn(details);
+
+        ConcertDate concertDates = concertService.selectAvailableDates(concertId);
+
+        // then
+        assertThat(concertDates.concertId()).isEqualTo(concertId);
+        assertThat(concertDates.concertDates().get(0).concertDetailId()).isEqualTo(1L);
+        assertThat(concertDates.concertDates().get(0).dates()).isEqualTo(today.format(formatter));
+    }
+
+    @DisplayName("콘서트 별 예약 가능한 좌석을 조회한다")
+    @Test
+    void getAvailableSeats() {
+        // given
+        Long concertDetailId = 1L;
+        Long seatId = 1L;
+        int seatNo = 1;
+
+        List<Seat> response = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Seat seat = Seat.builder()
+                    .id(seatId + i)
+                    .seatNo(seatNo + i)
+                    .build();
+
+            response.add(seat);
+        }
+
+        // when
+        when(concertRepository.findAvailableSeatsByConcertId(any(),any())).thenReturn(response);
+
+        ConcertSeat concertSeats = concertService.selectAvailableSeats(concertDetailId);
+
+        // then
+        assertThat(concertSeats.concertDetailId()).isEqualTo(concertDetailId);
+        assertThat(concertSeats.concertSeats().get(0).seatId()).isEqualTo(1L);
+        assertThat(concertSeats.concertSeats().get(0).seatNo()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/example/concertticketing/domain/pay/PayServiceTest.java
+++ b/src/test/java/com/example/concertticketing/domain/pay/PayServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.concertticketing.domain.pay;
+
+import com.example.concertticketing.api.pay.dto.PayRequest;
+import com.example.concertticketing.domain.concert.service.SeatServiceImpl;
+import com.example.concertticketing.domain.pay.model.Pay;
+import com.example.concertticketing.domain.pay.model.PayStatus;
+import com.example.concertticketing.domain.pay.repository.PayRepository;
+import com.example.concertticketing.domain.pay.service.PayServiceImpl;
+import com.example.concertticketing.domain.queue.service.QueueServiceImpl;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.service.ReservationServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PayServiceTest {
+    @Mock
+    private PayRepository payRepository;
+
+    @Mock
+    private ReservationServiceImpl reservationService;
+
+    @Mock
+    private QueueServiceImpl queueService;
+
+    @Mock
+    private SeatServiceImpl seatService;
+
+    @InjectMocks
+    private PayServiceImpl payService;
+
+    @DisplayName("예약 번호를 받아 결제한다")
+    @Test
+    void pay() {
+        // given
+        Long reservationId = 1L;
+        Long memberId = 1L;
+        Long seatId = 1L;
+        Long price = 5000L;
+
+        PayRequest request = new PayRequest(reservationId,memberId,seatId);
+
+        Reservation reservation = Reservation.builder()
+                .memberId(memberId)
+                .price(price)
+                .build();
+
+        // when
+        when(reservationService.findById(any())).thenReturn(reservation);
+        when(payRepository.pay(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Pay response = payService.pay(request);
+
+        // then
+        assertThat(response.getAmount()).isEqualTo(price);
+        assertThat(response.getStatus()).isEqualTo(PayStatus.PAYED);
+    }
+}

--- a/src/test/java/com/example/concertticketing/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/example/concertticketing/domain/reservation/service/ReservationServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.example.concertticketing.domain.reservation.service;
+
+import com.example.concertticketing.domain.concert.model.ConcertDetail;
+import com.example.concertticketing.domain.concert.model.Seat;
+import com.example.concertticketing.domain.concert.service.SeatServiceImpl;
+import com.example.concertticketing.domain.reservation.model.Reservation;
+import com.example.concertticketing.domain.reservation.model.ReservationStatus;
+import com.example.concertticketing.domain.reservation.repository.ReservationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceImplTest {
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private SeatServiceImpl seatService;
+
+    @InjectMocks
+    private ReservationServiceImpl reservationService;
+
+    @DisplayName("좌석을 예약한다")
+    @Test
+    void reserveSeat() {
+        // given
+        Long seatId = 1L;
+        ConcertDetail concert = ConcertDetail.builder()
+                .name("A1")
+                .build();
+        Seat seat = Seat.builder()
+                .concert(concert)
+                .build();
+
+        // when
+        when(seatService.selectSeat(any())).thenReturn(seat);
+        when(reservationRepository.reserveSeat(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Reservation response = reservationService.reserveSeat(seatId);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+        assertThat(response.getConcertName()).isEqualTo(concert.getName());
+    }
+}


### PR DESCRIPTION
### 예약 가능 날짜 / 좌석 조회
- 콘서트 아이디(concertId)로 콘서트별 날짜를 조회합니다
- 콘서트 날짜별 아이디(concertDetailId)로 해당 콘서트에 예약 가능한 좌석을 조회합니다
- API 반환 스펙은 리펙토링하며 변경중입니다

### 좌석 예약
- 좌석 예약 시 status가 TEMP로 변경되고 일정시간이 지나면 스케줄러에 의해 AVAILABLE 로 변경됩니다
- 추후, 결제 기능에서 결제 시 RESERVED로 변경되고 이 때부턴 스케줄러에 영향을 받지 않습니다

### 리뷰 포인트
- 좌석의 경우 status를 놓치 않고 Reservation 테이블과 조인 + 시간으로 구분을 하면 스케줄러가 돌지 않아도 되겠다는 생각을 했습니다. 차주 고도화 시 변경하려 하는데 해당 방식이 더 낫겟죠?
